### PR TITLE
Changed so Development config is only loaded in Development.  Cleaned…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ terraform.rc
 /.vs/slnx.sqlite
 /.vs/VSWorkspaceState.json
 /.vs
+.DS_Store

--- a/api/src/referenceApp.Api/Program.cs
+++ b/api/src/referenceApp.Api/Program.cs
@@ -47,11 +47,11 @@ namespace referenceApp.Api
                 var env = hostingContext.HostingEnvironment;
                 config
                     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                    .AddJsonFile($"appsettings.Development.json", optional: true, reloadOnChange: true)
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
 
                 if (env.IsDevelopment())
                 {
+                    config.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
                     config.AddUserSecrets<Program>(true);
                 }
                 config.AddEnvironmentVariables();

--- a/api/src/referenceApp.Api/appsettings.Development.json
+++ b/api/src/referenceApp.Api/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
 	"ConnectionStrings": {
-		"ReferenceAppConnectionString": "Data Source=localhost;Initial Catalog=reference_app_dev;User Id=sa;Password=21239Admin;"
+		"ReferenceAppConnectionString": ""
 	},
 	"Logging": {
 		"LogLevel": {


### PR DESCRIPTION
Discovered that the appsettings.Development.json file is loaded into configuration in all environments.   This could be problematic if configuration is different on the local machine than in upper regions.  Changed the code to only load the appsettings.Development.json file in the Development environment.  I also cleaned up the config to remove an old sql connection string.