### PR TITLE
Update NuGet packages to resolve build warnings.

### DIFF
--- a/api/src/referenceApp.Api/Startup.cs
+++ b/api/src/referenceApp.Api/Startup.cs
@@ -112,7 +112,7 @@ namespace referenceApp.Api
             });
 
             app.UseOpenApi();
-            app.UseSwaggerUi3();
+            app.UseSwaggerUi();
         }
     }
 }

--- a/api/src/referenceApp.Api/referenceApp.Api.csproj
+++ b/api/src/referenceApp.Api/referenceApp.Api.csproj
@@ -11,17 +11,17 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.47.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.FeatureManagement" Version="2.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.14.4" />
-    <PackageReference Include="NSwag.MSBuild" Version="13.14.4">
+    <PackageReference Include="NSwag.AspNetCore" Version="14.1.0" />
+    <PackageReference Include="NSwag.MSBuild" Version="14.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/api/src/referenceApp.Persistence/referenceApp.Persistence.csproj
+++ b/api/src/referenceApp.Persistence/referenceApp.Persistence.csproj
@@ -8,8 +8,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes several updates to package dependencies and a modification to the Swagger UI configuration. The most important changes are the upgrade of various package versions and the change from `UseSwaggerUi3` to `UseSwaggerUi`.

This PR __does not__ update all packages to the most current version.  It is currently limited to package updates to resolve build warnings.

Package dependency updates:

* [`api/src/referenceApp.Api/referenceApp.Api.csproj`](diffhunk://#diff-385b30738cc75b62badade1546a88b9c39bfba5aa02c76329158e830ac1ecf40L14-R24): Upgraded `Microsoft.Azure.Cosmos`, `Microsoft.EntityFrameworkCore.Cosmos`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Tools`, `NSwag.AspNetCore`, and `NSwag.MSBuild` to newer versions.
* [`api/src/referenceApp.Persistence/referenceApp.Persistence.csproj`](diffhunk://#diff-9d2ffea22bd896743e8fecb4b33a8c6f49dc5c0d4b78169744402a5776079359L11-R13): Upgraded `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.InMemory`, and `Microsoft.EntityFrameworkCore.Sqlite` to version 8.0.0.

Swagger UI configuration update:

* [`api/src/referenceApp.Api/Startup.cs`](diffhunk://#diff-61883d4ddb93db3bc57194c14586e71f52bd74cd0eb62bc16cb6a4f02fd342f8L115-R115): Changed the method call from `UseSwaggerUi3` to `UseSwaggerUi` (change in [NSwag v14 announcement](https://github.com/RicoSuter/NSwag/issues/4524))